### PR TITLE
refactor(api): extract AgentSessionHandler from websocket transport

### DIFF
--- a/legion/api/main.py
+++ b/legion/api/main.py
@@ -31,6 +31,7 @@ from legion.plumbing.database import create_engine
 from legion.plumbing.migrations import validate_database_schema_current
 from legion.plumbing.logging import LogFormat, LogOutput, setup_logging
 from legion.services.agent_delivery_service import AgentDeliveryService
+from legion.services.agent_session_handler import AgentSessionHandler
 from legion.services.agent_session_repository import AgentSessionRepository
 from legion.services.agent_session_repository import SQLiteAgentSessionRepository
 from legion.services.audit_event_repository import SQLiteAuditEventRepository
@@ -149,6 +150,12 @@ def create_app(
         app.state.agent_delivery_service = AgentDeliveryService(
             app.state.dispatch_service,
             app.state.fleet_repo,
+        )
+        app.state.agent_session_handler = AgentSessionHandler(
+            app.state.dispatch_service,
+            app.state.job_repo,
+            message_service=getattr(app.state, "message_service", None),
+            audit_service=getattr(app.state, "audit_service", None),
         )
 
         app.state.db_executor = ThreadPoolExecutor(max_workers=4)

--- a/legion/api/websocket.py
+++ b/legion/api/websocket.py
@@ -4,35 +4,23 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from functools import partial
-from typing import Any
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from pydantic import TypeAdapter, ValidationError
 
-from legion.domain.protocol import (
-    AgentToServerMessage,
-    AuditEventMessage,
-    HeartbeatMessage,
-    JobFailedMessage,
-    JobProgressMessage,
-    JobResultMessage,
-    JobStartedMessage,
-    MessageEmitMessage,
-)
+from legion.domain.protocol import AgentToServerMessage
 from legion.domain.agent import Agent
 from legion.domain.job import Job
 from legion.domain.prompt_config import PromptConfig
 from legion.services.agent_delivery_service import AgentDeliveryService
+from legion.services.agent_session_handler import AgentSessionHandler
 from legion.services.dispatch_service import DispatchService
 from legion.services.exceptions import (
     AgentNotFoundError,
-    DispatchError,
     InvalidSessionTokenError,
     SessionTokenMismatchError,
 )
 from legion.services.fleet_repository import FleetRepository
-from legion.services.job_repository import JobRepository
 
 logger = logging.getLogger(__name__)
 _AGENT_MESSAGE_ADAPTER: TypeAdapter[AgentToServerMessage] = TypeAdapter(AgentToServerMessage)
@@ -99,26 +87,13 @@ def _parse_agent_message(raw_message: str) -> AgentToServerMessage | None:
         return None
 
 
-def _verify_job_ownership(job: Job | None, agent_id: str, message_type: str) -> Job | None:
-    """Return the job if it exists and belongs to the agent, else None."""
-    if job is None:
-        return None
-    if job.agent_id != agent_id:
-        logger.warning(
-            "ownership_violation agent=%s sent %s for job %s owned by %s",
-            agent_id, message_type, job.id, job.agent_id,
-        )
-        return None
-    return job
-
-
 @router.websocket("/ws/agents/{agent_id}")
 async def agent_websocket(websocket: WebSocket, agent_id: str) -> None:
     fleet_repo: FleetRepository = websocket.app.state.fleet_repo
-    job_repo: JobRepository = websocket.app.state.job_repo
     dispatch_service: DispatchService = websocket.app.state.dispatch_service
     connection_manager: ConnectionManager = websocket.app.state.connection_manager
     agent_delivery_service: AgentDeliveryService = websocket.app.state.agent_delivery_service
+    agent_session_handler: AgentSessionHandler = websocket.app.state.agent_session_handler
     db_executor = websocket.app.state.db_executor
     loop = asyncio.get_running_loop()
 
@@ -156,142 +131,19 @@ async def agent_websocket(websocket: WebSocket, agent_id: str) -> None:
             if message is None:
                 continue
 
-            if isinstance(message, HeartbeatMessage):
-                await loop.run_in_executor(db_executor, dispatch_service.heartbeat, agent_id)
+            result = await loop.run_in_executor(
+                db_executor,
+                agent_session_handler.handle,
+                message,
+                agent_id,
+                agent.agent_group_id,
+            )
 
-            elif isinstance(message, JobStartedMessage):
-                job = _verify_job_ownership(
-                    await loop.run_in_executor(db_executor, job_repo.get_by_id, message.job_id),
-                    agent_id,
-                    "job_started",
-                )
-                if job is not None:
-                    job.start()
-                    await loop.run_in_executor(db_executor, job_repo.save, job)
-
-            elif isinstance(message, JobResultMessage):
-                try:
-                    await loop.run_in_executor(
-                        db_executor,
-                        partial(dispatch_service.complete_job, message.job_id, message.result, agent_id=agent_id),
-                    )
-                except DispatchError:
-                    logger.warning(
-                        "Ignoring job_result for unknown job %s from agent %s",
-                        message.job_id,
-                        agent_id,
-                    )
-                    continue
+            if result.dispatch_pending_for_group:
                 await agent_delivery_service.dispatch_pending_for_group(
-                    agent.agent_group_id,
+                    result.dispatch_pending_for_group,
                     connection_manager.send_job_to_agent,
                 )
-
-            elif isinstance(message, JobFailedMessage):
-                try:
-                    await loop.run_in_executor(
-                        db_executor,
-                        partial(dispatch_service.fail_job, message.job_id, message.error, agent_id=agent_id),
-                    )
-                except DispatchError:
-                    logger.warning(
-                        "Ignoring job_failed for unknown job %s from agent %s",
-                        message.job_id,
-                        agent_id,
-                    )
-                    continue
-                await agent_delivery_service.dispatch_pending_for_group(
-                    agent.agent_group_id,
-                    connection_manager.send_job_to_agent,
-                )
-
-            elif isinstance(message, JobProgressMessage):
-                job = _verify_job_ownership(
-                    await loop.run_in_executor(db_executor, job_repo.get_by_id, message.job_id),
-                    agent_id,
-                    "job_progress",
-                )
-                if job is not None:
-                    logger.info(
-                        "job_progress job=%s step=%s detail=%s seq=%d",
-                        message.job_id, message.step, message.detail, message.sequence,
-                    )
-
-            elif isinstance(message, MessageEmitMessage):
-                job = _verify_job_ownership(
-                    await loop.run_in_executor(db_executor, job_repo.get_by_id, message.job_id),
-                    agent_id,
-                    "message_emit",
-                )
-                if job is not None:
-                    message_service = getattr(websocket.app.state, "message_service", None)
-                    if message_service is not None:
-                        try:
-                            from legion.domain.message import AuthorType, Message, MessageType
-                            domain_message = Message(
-                                org_id=job.org_id,
-                                session_id=job.session_id,
-                                author_id=job.agent_id or agent_id,
-                                author_type=AuthorType.AGENT,
-                                message_type=MessageType(message.message_type),
-                                content=message.content,
-                                job_id=message.job_id,
-                                metadata=message.metadata,
-                            )
-                            await loop.run_in_executor(db_executor, message_service.emit, domain_message)
-                        except Exception:
-                            logger.warning(
-                                "Failed to persist message_emit for job %s from agent %s",
-                                message.job_id, agent_id, exc_info=True,
-                            )
-                    else:
-                        logger.debug("message_service not available, skipping message_emit for job %s", message.job_id)
-
-            elif isinstance(message, AuditEventMessage):
-                job = _verify_job_ownership(
-                    await loop.run_in_executor(db_executor, job_repo.get_by_id, message.job_id),
-                    agent_id,
-                    "audit_event",
-                )
-                if job is not None:
-                    audit_service = getattr(websocket.app.state, "audit_service", None)
-                    if audit_service is not None:
-                        try:
-                            from legion.domain.audit_event import AuditAction, AuditEvent
-
-                            try:
-                                audit_action = AuditAction(message.action)
-                            except ValueError:
-                                logger.warning("Unknown audit action %r, defaulting to TOOL_CALL", message.action)
-                                audit_action = AuditAction.TOOL_CALL
-
-                            output_dict: dict[str, Any] | None = None
-                            if message.tool_output is not None or message.error is not None:
-                                output_dict = {}
-                                if message.tool_output is not None:
-                                    output_dict["raw"] = message.tool_output
-                                if message.error is not None:
-                                    output_dict["error"] = message.error
-
-                            audit_event = AuditEvent(
-                                job_id=message.job_id,
-                                agent_id=job.agent_id or agent_id,
-                                session_id=job.session_id,
-                                org_id=job.org_id,
-                                action=audit_action,
-                                tool_name=message.tool_name,
-                                input={"raw": message.tool_input},
-                                output=output_dict,
-                                duration_ms=message.duration_ms,
-                            )
-                            await loop.run_in_executor(db_executor, audit_service.emit, audit_event)
-                        except Exception:
-                            logger.warning(
-                                "Failed to persist audit_event for job %s from agent %s",
-                                message.job_id, agent_id, exc_info=True,
-                            )
-                    else:
-                        logger.debug("audit_service not available, skipping audit_event for job %s", message.job_id)
 
     except (WebSocketDisconnect, asyncio.CancelledError):
         pass

--- a/legion/services/agent_session_handler.py
+++ b/legion/services/agent_session_handler.py
@@ -1,0 +1,310 @@
+"""Agent session handler — extracts protocol/business logic from the WebSocket transport layer.
+
+Processes parsed agent-to-server messages and returns result objects describing
+the effects the caller (transport layer) should perform. This keeps the handler
+fully synchronous and testable without any WebSocket or asyncio dependency.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, assert_never
+
+from legion.domain.audit_event import AuditAction, AuditEvent
+from legion.domain.job import Job
+from legion.domain.message import AuthorType, Message, MessageType
+from legion.domain.protocol import (
+    AgentToServerMessage,
+    AuditEventMessage,
+    HeartbeatMessage,
+    JobFailedMessage,
+    JobProgressMessage,
+    JobResultMessage,
+    JobStartedMessage,
+    MessageEmitMessage,
+)
+from legion.services.audit_service import AuditService
+from legion.services.dispatch_service import DispatchService
+from legion.services.exceptions import DispatchError
+from legion.services.job_repository import JobRepository
+from legion.services.message_service import MessageService
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result objects — describe effects the transport layer should perform
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HandleResult:
+    """Outcome of processing a single agent-to-server message.
+
+    Attributes:
+        dispatch_pending_for_group: If set, the transport layer should trigger
+            ``agent_delivery_service.dispatch_pending_for_group`` for this group.
+        ignored: True when the message was silently dropped (e.g. ownership
+            violation, unknown job, DispatchError).
+    """
+
+    dispatch_pending_for_group: str | None = None
+    ignored: bool = False
+
+
+_IGNORED = HandleResult(ignored=True)
+_OK = HandleResult()
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+class AgentSessionHandler:
+    """Processes parsed agent-to-server messages, applying business logic.
+
+    All dependencies are constructor-injected.  ``message_service`` and
+    ``audit_service`` are optional — when ``None`` the corresponding message
+    types are silently skipped with a debug log.
+    """
+
+    def __init__(
+        self,
+        dispatch_service: DispatchService,
+        job_repo: JobRepository,
+        *,
+        message_service: MessageService | None = None,
+        audit_service: AuditService | None = None,
+    ) -> None:
+        self._dispatch_service = dispatch_service
+        self._job_repo = job_repo
+        self._message_service = message_service
+        self._audit_service = audit_service
+
+    # -- public entry point -------------------------------------------------
+
+    def handle(
+        self,
+        message: AgentToServerMessage,
+        agent_id: str,
+        agent_group_id: str,
+    ) -> HandleResult:
+        """Dispatch *message* to the appropriate handler method.
+
+        Returns a :class:`HandleResult` telling the caller what side-effects
+        to perform (e.g. dispatching pending work for a group).
+        """
+        if isinstance(message, HeartbeatMessage):
+            return self._handle_heartbeat(agent_id)
+
+        if isinstance(message, JobStartedMessage):
+            return self._handle_job_started(message, agent_id)
+
+        if isinstance(message, JobResultMessage):
+            return self._handle_job_result(message, agent_id, agent_group_id)
+
+        if isinstance(message, JobFailedMessage):
+            return self._handle_job_failed(message, agent_id, agent_group_id)
+
+        if isinstance(message, JobProgressMessage):
+            return self._handle_job_progress(message, agent_id)
+
+        if isinstance(message, MessageEmitMessage):
+            return self._handle_message_emit(message, agent_id)
+
+        if isinstance(message, AuditEventMessage):
+            return self._handle_audit_event(message, agent_id)
+
+        assert_never(message)
+
+    # -- individual handlers ------------------------------------------------
+
+    def _handle_heartbeat(self, agent_id: str) -> HandleResult:
+        self._dispatch_service.heartbeat(agent_id)
+        return _OK
+
+    def _handle_job_started(
+        self,
+        message: JobStartedMessage,
+        agent_id: str,
+    ) -> HandleResult:
+        job = self._verify_job_ownership(
+            self._job_repo.get_by_id(message.job_id),
+            agent_id,
+            "job_started",
+        )
+        if job is None:
+            return _IGNORED
+        job.start()
+        self._job_repo.save(job)
+        return _OK
+
+    def _handle_job_result(
+        self,
+        message: JobResultMessage,
+        agent_id: str,
+        agent_group_id: str,
+    ) -> HandleResult:
+        try:
+            self._dispatch_service.complete_job(
+                message.job_id, message.result, agent_id=agent_id,
+            )
+        except DispatchError:
+            logger.warning(
+                "Ignoring job_result for unknown job %s from agent %s",
+                message.job_id,
+                agent_id,
+            )
+            return _IGNORED
+        return HandleResult(dispatch_pending_for_group=agent_group_id)
+
+    def _handle_job_failed(
+        self,
+        message: JobFailedMessage,
+        agent_id: str,
+        agent_group_id: str,
+    ) -> HandleResult:
+        try:
+            self._dispatch_service.fail_job(
+                message.job_id, message.error, agent_id=agent_id,
+            )
+        except DispatchError:
+            logger.warning(
+                "Ignoring job_failed for unknown job %s from agent %s",
+                message.job_id,
+                agent_id,
+            )
+            return _IGNORED
+        return HandleResult(dispatch_pending_for_group=agent_group_id)
+
+    def _handle_job_progress(
+        self,
+        message: JobProgressMessage,
+        agent_id: str,
+    ) -> HandleResult:
+        job = self._verify_job_ownership(
+            self._job_repo.get_by_id(message.job_id),
+            agent_id,
+            "job_progress",
+        )
+        if job is None:
+            return _IGNORED
+        logger.info(
+            "job_progress job=%s step=%s detail=%s seq=%d",
+            message.job_id, message.step, message.detail, message.sequence,
+        )
+        return _OK
+
+    def _handle_message_emit(
+        self,
+        message: MessageEmitMessage,
+        agent_id: str,
+    ) -> HandleResult:
+        job = self._verify_job_ownership(
+            self._job_repo.get_by_id(message.job_id),
+            agent_id,
+            "message_emit",
+        )
+        if job is None:
+            return _IGNORED
+
+        if self._message_service is None:
+            logger.debug(
+                "message_service not available, skipping message_emit for job %s",
+                message.job_id,
+            )
+            return _OK
+
+        try:
+            domain_message = Message(
+                org_id=job.org_id,
+                session_id=job.session_id,
+                author_id=job.agent_id or agent_id,
+                author_type=AuthorType.AGENT,
+                message_type=MessageType(message.message_type),
+                content=message.content,
+                job_id=message.job_id,
+                metadata=message.metadata,
+            )
+            self._message_service.emit(domain_message)
+        except Exception:
+            logger.warning(
+                "Failed to persist message_emit for job %s from agent %s",
+                message.job_id, agent_id, exc_info=True,
+            )
+        return _OK
+
+    def _handle_audit_event(
+        self,
+        message: AuditEventMessage,
+        agent_id: str,
+    ) -> HandleResult:
+        job = self._verify_job_ownership(
+            self._job_repo.get_by_id(message.job_id),
+            agent_id,
+            "audit_event",
+        )
+        if job is None:
+            return _IGNORED
+
+        if self._audit_service is None:
+            logger.debug(
+                "audit_service not available, skipping audit_event for job %s",
+                message.job_id,
+            )
+            return _OK
+
+        try:
+            try:
+                audit_action = AuditAction(message.action)
+            except ValueError:
+                logger.warning("Unknown audit action %r, defaulting to TOOL_CALL", message.action)
+                audit_action = AuditAction.TOOL_CALL
+
+            output_dict: dict[str, Any] | None = None
+            if message.tool_output is not None or message.error is not None:
+                output_dict = {}
+                if message.tool_output is not None:
+                    output_dict["raw"] = message.tool_output
+                if message.error is not None:
+                    output_dict["error"] = message.error
+
+            audit_event = AuditEvent(
+                job_id=message.job_id,
+                agent_id=job.agent_id or agent_id,
+                session_id=job.session_id,
+                org_id=job.org_id,
+                action=audit_action,
+                tool_name=message.tool_name,
+                input={"raw": message.tool_input},
+                output=output_dict,
+                duration_ms=message.duration_ms,
+            )
+            self._audit_service.emit(audit_event)
+        except Exception:
+            logger.warning(
+                "Failed to persist audit_event for job %s from agent %s",
+                message.job_id, agent_id, exc_info=True,
+            )
+        return _OK
+
+    # -- helpers ------------------------------------------------------------
+
+    @staticmethod
+    def _verify_job_ownership(
+        job: Job | None,
+        agent_id: str,
+        message_type: str,
+    ) -> Job | None:
+        """Return the job if it exists and belongs to the agent, else None."""
+        if job is None:
+            return None
+        if job.agent_id != agent_id:
+            logger.warning(
+                "ownership_violation agent=%s sent %s for job %s owned by %s",
+                agent_id, message_type, job.id, job.agent_id,
+            )
+            return None
+        return job

--- a/tests/test_services_agent_session_handler.py
+++ b/tests/test_services_agent_session_handler.py
@@ -1,0 +1,678 @@
+"""Unit tests for AgentSessionHandler — the extracted protocol/business logic layer."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from legion.domain.audit_event import AuditAction, AuditEvent
+from legion.domain.job import Job, JobStatus, JobType
+from legion.domain.message import AuthorType, Message, MessageType
+from legion.domain.protocol import (
+    AuditEventMessage,
+    HeartbeatMessage,
+    JobFailedMessage,
+    JobProgressMessage,
+    JobResultMessage,
+    JobStartedMessage,
+    MessageEmitMessage,
+)
+from legion.services.agent_session_handler import (
+    AgentSessionHandler,
+    HandleResult,
+)
+from legion.services.exceptions import DispatchError
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+JOB_ID = "job-001"
+AGENT_ID = "agent-001"
+OTHER_AGENT_ID = "agent-other"
+SESSION_ID = "session-001"
+ORG_ID = "org-001"
+GROUP_ID = "ag-001"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_job(**overrides: Any) -> Job:
+    defaults: dict[str, Any] = dict(
+        id=JOB_ID,
+        org_id=ORG_ID,
+        agent_group_id=GROUP_ID,
+        session_id=SESSION_ID,
+        agent_id=AGENT_ID,
+        type=JobType.QUERY,
+        status=JobStatus.RUNNING,
+        payload="check pods",
+    )
+    defaults.update(overrides)
+    return Job(**defaults)
+
+
+def _make_handler(
+    *,
+    job: Job | None = None,
+    message_service: Any | None = None,
+    audit_service: Any | None = None,
+    dispatch_service: Any | None = None,
+    job_repo: Any | None = None,
+) -> AgentSessionHandler:
+    """Build an AgentSessionHandler with mock dependencies."""
+    if dispatch_service is None:
+        dispatch_service = MagicMock()
+    if job_repo is None:
+        job_repo = MagicMock()
+        job_repo.get_by_id.return_value = job
+    return AgentSessionHandler(
+        dispatch_service=dispatch_service,
+        job_repo=job_repo,
+        message_service=message_service,
+        audit_service=audit_service,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeat:
+    def test_heartbeat_calls_dispatch_service(self) -> None:
+        dispatch = MagicMock()
+        handler = _make_handler(dispatch_service=dispatch)
+
+        result = handler.handle(HeartbeatMessage(), AGENT_ID, GROUP_ID)
+
+        dispatch.heartbeat.assert_called_once_with(AGENT_ID)
+        assert result == HandleResult()
+        assert result.dispatch_pending_for_group is None
+        assert result.ignored is False
+
+
+# ---------------------------------------------------------------------------
+# JobStarted
+# ---------------------------------------------------------------------------
+
+
+class TestJobStarted:
+    def test_job_started_transitions_and_saves(self) -> None:
+        job = _make_job(status=JobStatus.DISPATCHED)
+        job_repo = MagicMock()
+        job_repo.get_by_id.return_value = job
+        handler = _make_handler(job_repo=job_repo)
+
+        msg = JobStartedMessage(job_id=JOB_ID)
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert job.status == JobStatus.RUNNING
+        job_repo.save.assert_called_once_with(job)
+        assert not result.ignored
+        assert result.dispatch_pending_for_group is None
+
+    def test_job_started_ignored_when_job_not_found(self) -> None:
+        handler = _make_handler(job=None)
+
+        msg = JobStartedMessage(job_id=JOB_ID)
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert result.ignored
+
+    def test_job_started_ignored_when_owned_by_other(self) -> None:
+        job = _make_job(agent_id=OTHER_AGENT_ID)
+        handler = _make_handler(job=job)
+
+        msg = JobStartedMessage(job_id=JOB_ID)
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert result.ignored
+
+
+# ---------------------------------------------------------------------------
+# JobResult
+# ---------------------------------------------------------------------------
+
+
+class TestJobResult:
+    def test_job_result_completes_and_requests_dispatch(self) -> None:
+        dispatch = MagicMock()
+        handler = _make_handler(dispatch_service=dispatch)
+
+        msg = JobResultMessage(job_id=JOB_ID, result="all pods healthy")
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        dispatch.complete_job.assert_called_once_with(
+            JOB_ID, "all pods healthy", agent_id=AGENT_ID,
+        )
+        assert result.dispatch_pending_for_group == GROUP_ID
+        assert not result.ignored
+
+    def test_job_result_ignored_on_dispatch_error(self) -> None:
+        dispatch = MagicMock()
+        dispatch.complete_job.side_effect = DispatchError("not found")
+        handler = _make_handler(dispatch_service=dispatch)
+
+        msg = JobResultMessage(job_id=JOB_ID, result="result")
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert result.ignored
+        assert result.dispatch_pending_for_group is None
+
+
+# ---------------------------------------------------------------------------
+# JobFailed
+# ---------------------------------------------------------------------------
+
+
+class TestJobFailed:
+    def test_job_failed_marks_failed_and_requests_dispatch(self) -> None:
+        dispatch = MagicMock()
+        handler = _make_handler(dispatch_service=dispatch)
+
+        msg = JobFailedMessage(job_id=JOB_ID, error="timeout")
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        dispatch.fail_job.assert_called_once_with(
+            JOB_ID, "timeout", agent_id=AGENT_ID,
+        )
+        assert result.dispatch_pending_for_group == GROUP_ID
+        assert not result.ignored
+
+    def test_job_failed_ignored_on_dispatch_error(self) -> None:
+        dispatch = MagicMock()
+        dispatch.fail_job.side_effect = DispatchError("not found")
+        handler = _make_handler(dispatch_service=dispatch)
+
+        msg = JobFailedMessage(job_id=JOB_ID, error="timeout")
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert result.ignored
+        assert result.dispatch_pending_for_group is None
+
+
+# ---------------------------------------------------------------------------
+# JobProgress
+# ---------------------------------------------------------------------------
+
+
+class TestJobProgress:
+    def test_job_progress_logs_info(self, caplog: pytest.LogCaptureFixture) -> None:
+        job = _make_job()
+        handler = _make_handler(job=job)
+
+        msg = JobProgressMessage(
+            job_id=JOB_ID, step="fetching_pods", detail="namespace=default", sequence=1,
+        )
+        with caplog.at_level(logging.INFO, logger="legion.services.agent_session_handler"):
+            result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert not result.ignored
+        progress_records = [r for r in caplog.records if "job_progress" in r.message]
+        assert len(progress_records) >= 1
+        assert "fetching_pods" in progress_records[0].message
+        assert JOB_ID in progress_records[0].message
+
+    def test_job_progress_ignored_when_job_not_found(self) -> None:
+        handler = _make_handler(job=None)
+
+        msg = JobProgressMessage(job_id=JOB_ID, step="s", detail="d", sequence=1)
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert result.ignored
+
+    def test_job_progress_ignored_when_owned_by_other(self) -> None:
+        job = _make_job(agent_id=OTHER_AGENT_ID)
+        handler = _make_handler(job=job)
+
+        msg = JobProgressMessage(job_id=JOB_ID, step="s", detail="d", sequence=1)
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert result.ignored
+
+
+# ---------------------------------------------------------------------------
+# MessageEmit
+# ---------------------------------------------------------------------------
+
+
+class TestMessageEmit:
+    def test_message_emit_persists_via_service(self) -> None:
+        job = _make_job()
+        message_service = MagicMock()
+        handler = _make_handler(job=job, message_service=message_service)
+
+        msg = MessageEmitMessage(
+            job_id=JOB_ID,
+            message_type="AGENT_FINDING",
+            content="Found 3 unhealthy pods",
+            metadata={"cluster": "prod"},
+        )
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert not result.ignored
+        message_service.emit.assert_called_once()
+        emitted: Message = message_service.emit.call_args[0][0]
+
+        assert isinstance(emitted, Message)
+        assert emitted.author_type == AuthorType.AGENT
+        assert emitted.author_id == AGENT_ID
+        assert emitted.org_id == ORG_ID
+        assert emitted.session_id == SESSION_ID
+        assert emitted.job_id == JOB_ID
+        assert emitted.message_type == MessageType.AGENT_FINDING
+        assert emitted.content == "Found 3 unhealthy pods"
+        assert emitted.metadata == {"cluster": "prod"}
+
+    def test_message_emit_empty_metadata_default(self) -> None:
+        job = _make_job()
+        message_service = MagicMock()
+        handler = _make_handler(job=job, message_service=message_service)
+
+        msg = MessageEmitMessage(
+            job_id=JOB_ID, message_type="STATUS_UPDATE", content="status",
+        )
+        handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        emitted: Message = message_service.emit.call_args[0][0]
+        assert emitted.metadata == {}
+
+    def test_message_emit_uses_job_agent_id_over_caller_agent_id(self) -> None:
+        """When job.agent_id is set, it's preferred over the caller's agent_id."""
+        job = _make_job(agent_id=AGENT_ID)
+        message_service = MagicMock()
+        handler = _make_handler(job=job, message_service=message_service)
+
+        msg = MessageEmitMessage(
+            job_id=JOB_ID, message_type="AGENT_FINDING", content="c",
+        )
+        handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        emitted: Message = message_service.emit.call_args[0][0]
+        assert emitted.author_id == AGENT_ID
+
+    def test_message_emit_without_service_skips_gracefully(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        job = _make_job()
+        handler = _make_handler(job=job, message_service=None)
+
+        msg = MessageEmitMessage(
+            job_id=JOB_ID, message_type="AGENT_FINDING", content="some content",
+        )
+        with caplog.at_level(logging.DEBUG, logger="legion.services.agent_session_handler"):
+            result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert not result.ignored
+        assert any("message_service not available" in r.message for r in caplog.records)
+        debug_records = [
+            r for r in caplog.records if "message_service not available" in r.message
+        ]
+        assert all(r.levelno == logging.DEBUG for r in debug_records)
+
+    def test_message_emit_skipped_when_job_owned_by_other(self) -> None:
+        job = _make_job(agent_id=OTHER_AGENT_ID)
+        message_service = MagicMock()
+        handler = _make_handler(job=job, message_service=message_service)
+
+        msg = MessageEmitMessage(
+            job_id=JOB_ID, message_type="AGENT_FINDING", content="should not persist",
+        )
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert result.ignored
+        message_service.emit.assert_not_called()
+
+    def test_message_emit_skipped_when_job_not_found(self) -> None:
+        message_service = MagicMock()
+        handler = _make_handler(job=None, message_service=message_service)
+
+        msg = MessageEmitMessage(
+            job_id=JOB_ID, message_type="AGENT_FINDING", content="should not persist",
+        )
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert result.ignored
+        message_service.emit.assert_not_called()
+
+    def test_message_emit_exception_is_caught_and_logged(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        job = _make_job()
+        message_service = MagicMock()
+        message_service.emit.side_effect = RuntimeError("db error")
+        handler = _make_handler(job=job, message_service=message_service)
+
+        msg = MessageEmitMessage(
+            job_id=JOB_ID, message_type="AGENT_FINDING", content="c",
+        )
+        with caplog.at_level(logging.WARNING, logger="legion.services.agent_session_handler"):
+            result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert not result.ignored  # still returns OK — failure is logged, not raised
+        assert any("Failed to persist message_emit" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# AuditEvent
+# ---------------------------------------------------------------------------
+
+
+class TestAuditEvent:
+    def test_audit_event_persists_via_service(self) -> None:
+        job = _make_job()
+        audit_service = MagicMock()
+        handler = _make_handler(job=job, audit_service=audit_service)
+
+        msg = AuditEventMessage(
+            job_id=JOB_ID,
+            tool_name="kubectl_get_pods",
+            tool_input="--namespace default",
+            tool_output="NAME  READY  STATUS\npod-1  1/1  Running",
+            duration_ms=150,
+            sequence=1,
+        )
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert not result.ignored
+        audit_service.emit.assert_called_once()
+        emitted: AuditEvent = audit_service.emit.call_args[0][0]
+
+        assert isinstance(emitted, AuditEvent)
+        assert emitted.action == AuditAction.TOOL_CALL
+        assert emitted.agent_id == AGENT_ID
+        assert emitted.job_id == JOB_ID
+        assert emitted.session_id == SESSION_ID
+        assert emitted.org_id == ORG_ID
+        assert emitted.tool_name == "kubectl_get_pods"
+        assert emitted.input == {"raw": "--namespace default"}
+        assert emitted.output == {"raw": "NAME  READY  STATUS\npod-1  1/1  Running"}
+        assert emitted.duration_ms == 150
+
+    def test_audit_event_maps_known_action(self) -> None:
+        job = _make_job()
+        audit_service = MagicMock()
+        handler = _make_handler(job=job, audit_service=audit_service)
+
+        msg = AuditEventMessage(
+            job_id=JOB_ID,
+            tool_name="llm_router",
+            tool_input="prompt",
+            tool_output="decision",
+            duration_ms=50,
+            sequence=1,
+            action="LLM_DECISION",
+        )
+        handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        emitted: AuditEvent = audit_service.emit.call_args[0][0]
+        assert emitted.action == AuditAction.LLM_DECISION
+
+    def test_audit_event_maps_error_to_output(self) -> None:
+        job = _make_job()
+        audit_service = MagicMock()
+        handler = _make_handler(job=job, audit_service=audit_service)
+
+        msg = AuditEventMessage(
+            job_id=JOB_ID,
+            tool_name="kubectl_get_pods",
+            tool_input="--namespace default",
+            tool_output="partial output",
+            duration_ms=200,
+            sequence=1,
+            error="connection refused",
+        )
+        handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        emitted: AuditEvent = audit_service.emit.call_args[0][0]
+        assert emitted.output == {"raw": "partial output", "error": "connection refused"}
+
+    def test_audit_event_output_with_only_error(self) -> None:
+        """When tool_output is present but error is also set, both appear in output."""
+        job = _make_job()
+        audit_service = MagicMock()
+        handler = _make_handler(job=job, audit_service=audit_service)
+
+        msg = AuditEventMessage(
+            job_id=JOB_ID,
+            tool_name="tool",
+            tool_input="in",
+            tool_output="out",
+            duration_ms=10,
+            sequence=1,
+            error="err",
+        )
+        handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        emitted: AuditEvent = audit_service.emit.call_args[0][0]
+        assert emitted.output == {"raw": "out", "error": "err"}
+
+    def test_audit_event_output_without_error(self) -> None:
+        """When error is None, output dict has only 'raw'."""
+        job = _make_job()
+        audit_service = MagicMock()
+        handler = _make_handler(job=job, audit_service=audit_service)
+
+        msg = AuditEventMessage(
+            job_id=JOB_ID,
+            tool_name="tool",
+            tool_input="in",
+            tool_output="out",
+            duration_ms=10,
+            sequence=1,
+            error=None,
+        )
+        handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        emitted: AuditEvent = audit_service.emit.call_args[0][0]
+        assert emitted.output == {"raw": "out"}
+
+    def test_audit_event_unknown_action_defaults_to_tool_call(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        job = _make_job()
+        audit_service = MagicMock()
+        handler = _make_handler(job=job, audit_service=audit_service)
+
+        msg = AuditEventMessage(
+            job_id=JOB_ID,
+            tool_name="some_tool",
+            tool_input="in",
+            tool_output="out",
+            duration_ms=10,
+            sequence=1,
+            action="UNKNOWN_ACTION",
+        )
+        with caplog.at_level(logging.WARNING, logger="legion.services.agent_session_handler"):
+            handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        emitted: AuditEvent = audit_service.emit.call_args[0][0]
+        assert emitted.action == AuditAction.TOOL_CALL
+        assert any("Unknown audit action" in r.message for r in caplog.records)
+
+    def test_audit_event_without_service_skips_gracefully(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        job = _make_job()
+        handler = _make_handler(job=job, audit_service=None)
+
+        msg = AuditEventMessage(
+            job_id=JOB_ID,
+            tool_name="kubectl_get_pods",
+            tool_input="input",
+            tool_output="output",
+            duration_ms=10,
+            sequence=1,
+        )
+        with caplog.at_level(logging.DEBUG, logger="legion.services.agent_session_handler"):
+            result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert not result.ignored
+        assert any("audit_service not available" in r.message for r in caplog.records)
+        debug_records = [
+            r for r in caplog.records if "audit_service not available" in r.message
+        ]
+        assert all(r.levelno == logging.DEBUG for r in debug_records)
+
+    def test_audit_event_populates_fields_from_job(self) -> None:
+        """Verify session_id and org_id are sourced from the job, not the message."""
+        job = _make_job(session_id="sess-custom", org_id="org-custom")
+        audit_service = MagicMock()
+        handler = _make_handler(job=job, audit_service=audit_service)
+
+        msg = AuditEventMessage(
+            job_id=JOB_ID,
+            tool_name="tool",
+            tool_input="in",
+            tool_output="out",
+            duration_ms=5,
+            sequence=1,
+        )
+        handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        emitted: AuditEvent = audit_service.emit.call_args[0][0]
+        assert emitted.session_id == "sess-custom"
+        assert emitted.org_id == "org-custom"
+
+    def test_audit_event_skipped_when_job_owned_by_other(self) -> None:
+        job = _make_job(agent_id=OTHER_AGENT_ID)
+        audit_service = MagicMock()
+        handler = _make_handler(job=job, audit_service=audit_service)
+
+        msg = AuditEventMessage(
+            job_id=JOB_ID,
+            tool_name="tool",
+            tool_input="in",
+            tool_output="out",
+            duration_ms=5,
+            sequence=1,
+        )
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert result.ignored
+        audit_service.emit.assert_not_called()
+
+    def test_audit_event_skipped_when_job_not_found(self) -> None:
+        audit_service = MagicMock()
+        handler = _make_handler(job=None, audit_service=audit_service)
+
+        msg = AuditEventMessage(
+            job_id=JOB_ID,
+            tool_name="tool",
+            tool_input="in",
+            tool_output="out",
+            duration_ms=5,
+            sequence=1,
+        )
+        result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert result.ignored
+        audit_service.emit.assert_not_called()
+
+    def test_audit_event_exception_is_caught_and_logged(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        job = _make_job()
+        audit_service = MagicMock()
+        audit_service.emit.side_effect = RuntimeError("db error")
+        handler = _make_handler(job=job, audit_service=audit_service)
+
+        msg = AuditEventMessage(
+            job_id=JOB_ID,
+            tool_name="tool",
+            tool_input="in",
+            tool_output="out",
+            duration_ms=10,
+            sequence=1,
+        )
+        with caplog.at_level(logging.WARNING, logger="legion.services.agent_session_handler"):
+            result = handler.handle(msg, AGENT_ID, GROUP_ID)
+
+        assert not result.ignored
+        assert any("Failed to persist audit_event" in r.message for r in caplog.records)
+
+    def test_audit_event_all_known_actions(self) -> None:
+        """Every AuditAction enum value is accepted without fallback."""
+        for action in AuditAction:
+            job = _make_job()
+            audit_service = MagicMock()
+            handler = _make_handler(job=job, audit_service=audit_service)
+
+            msg = AuditEventMessage(
+                job_id=JOB_ID,
+                tool_name="t",
+                tool_input="i",
+                tool_output="o",
+                duration_ms=1,
+                sequence=1,
+                action=action.value,
+            )
+            handler.handle(msg, AGENT_ID, GROUP_ID)
+
+            emitted: AuditEvent = audit_service.emit.call_args[0][0]
+            assert emitted.action == action
+
+
+# ---------------------------------------------------------------------------
+# Job ownership verification (cross-cutting)
+# ---------------------------------------------------------------------------
+
+
+class TestJobOwnershipVerification:
+    def test_ownership_passes_when_agent_matches(self) -> None:
+        job = _make_job(agent_id=AGENT_ID)
+        result = AgentSessionHandler._verify_job_ownership(job, AGENT_ID, "test")
+        assert result is job
+
+    def test_ownership_fails_when_agent_differs(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        job = _make_job(agent_id=OTHER_AGENT_ID)
+        with caplog.at_level(logging.WARNING, logger="legion.services.agent_session_handler"):
+            result = AgentSessionHandler._verify_job_ownership(job, AGENT_ID, "test_msg")
+
+        assert result is None
+        assert any("ownership_violation" in r.message for r in caplog.records)
+        violation_record = next(r for r in caplog.records if "ownership_violation" in r.message)
+        assert AGENT_ID in violation_record.message
+        assert OTHER_AGENT_ID in violation_record.message
+        assert "test_msg" in violation_record.message
+
+    def test_ownership_returns_none_when_job_is_none(self) -> None:
+        result = AgentSessionHandler._verify_job_ownership(None, AGENT_ID, "test")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# HandleResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestHandleResult:
+    def test_defaults(self) -> None:
+        r = HandleResult()
+        assert r.dispatch_pending_for_group is None
+        assert r.ignored is False
+
+    def test_dispatch_pending(self) -> None:
+        r = HandleResult(dispatch_pending_for_group="ag-1")
+        assert r.dispatch_pending_for_group == "ag-1"
+        assert r.ignored is False
+
+    def test_ignored(self) -> None:
+        r = HandleResult(ignored=True)
+        assert r.dispatch_pending_for_group is None
+        assert r.ignored is True
+
+    def test_frozen(self) -> None:
+        r = HandleResult()
+        with pytest.raises(AttributeError):
+            r.ignored = True  # type: ignore[misc]

--- a/tests/test_websocket_handlers.py
+++ b/tests/test_websocket_handlers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -18,6 +18,7 @@ from legion.domain.protocol import (
     JobProgressMessage,
     MessageEmitMessage,
 )
+from legion.services.agent_session_handler import AgentSessionHandler
 
 
 JOB_ID = "job-001"
@@ -68,19 +69,22 @@ def _make_app_state(
     agent_delivery_service = MagicMock()
     agent_delivery_service.dispatch_pending_for_group = AsyncMock()
 
+    agent_session_handler = AgentSessionHandler(
+        dispatch_service,
+        job_repo,
+        message_service=message_service,
+        audit_service=audit_service,
+    )
+
     state = SimpleNamespace(
         fleet_repo=fleet_repo,
         job_repo=job_repo,
         dispatch_service=dispatch_service,
         connection_manager=connection_manager,
         agent_delivery_service=agent_delivery_service,
+        agent_session_handler=agent_session_handler,
         db_executor=None,  # run_in_executor(None, ...) uses default executor
     )
-
-    if message_service is not None:
-        state.message_service = message_service
-    if audit_service is not None:
-        state.audit_service = audit_service
 
     return state
 
@@ -157,7 +161,7 @@ class TestMessageEmitHandler:
         raw = msg.model_dump_json()
         ws = _make_websocket(state, [raw])
 
-        with caplog.at_level(logging.DEBUG, logger="legion.api.websocket"):
+        with caplog.at_level(logging.DEBUG, logger="legion.services.agent_session_handler"):
             asyncio.run(agent_websocket(ws, AGENT_ID))
 
         assert any("message_service not available" in record.message for record in caplog.records)
@@ -285,7 +289,7 @@ class TestAuditEventHandler:
         )
         ws = _make_websocket(state, [msg.model_dump_json()])
 
-        with caplog.at_level(logging.WARNING, logger="legion.api.websocket"):
+        with caplog.at_level(logging.WARNING, logger="legion.services.agent_session_handler"):
             asyncio.run(agent_websocket(ws, AGENT_ID))
 
         audit_service.emit.assert_called_once()
@@ -308,7 +312,7 @@ class TestAuditEventHandler:
         )
         ws = _make_websocket(state, [msg.model_dump_json()])
 
-        with caplog.at_level(logging.DEBUG, logger="legion.api.websocket"):
+        with caplog.at_level(logging.DEBUG, logger="legion.services.agent_session_handler"):
             asyncio.run(agent_websocket(ws, AGENT_ID))
 
         assert any("audit_service not available" in record.message for record in caplog.records)
@@ -357,7 +361,7 @@ class TestJobProgressHandler:
         )
         ws = _make_websocket(state, [msg.model_dump_json()])
 
-        with caplog.at_level(logging.INFO, logger="legion.api.websocket"):
+        with caplog.at_level(logging.INFO, logger="legion.services.agent_session_handler"):
             asyncio.run(agent_websocket(ws, AGENT_ID))
 
         progress_records = [r for r in caplog.records if "job_progress" in r.message]


### PR DESCRIPTION
Move protocol dispatch and business logic out of websocket.py into a synchronous, transport-agnostic AgentSessionHandler in the services layer. 
Handler returns HandleResult describing side-effects; the surface decides how to perform them. 
Enables swapping the transport (e.g. gRPC) without touching services or domain.